### PR TITLE
Match overscroll background to page gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
       }
 
       * { box-sizing: border-box; }
-      html { scroll-behavior: smooth; }
+      html {
+        scroll-behavior: smooth;
+        background: linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 100%);
+      }
       @media (prefers-reduced-motion: reduce) {
         html { scroll-behavior: auto; }
         * { transition: none !important; animation: none !important; }


### PR DESCRIPTION
## Summary
- Give the `html` element the same top-to-bottom gradient as `body`, so macOS rubber-band overscroll at the top or bottom reveals the same color as the adjacent page edge instead of white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)