### PR TITLE
Solid background-color fallback for overscroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
       * { box-sizing: border-box; }
       html {
         scroll-behavior: smooth;
-        background: linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 100%);
+        background-color: var(--bg);
+        background-image: linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 100%);
       }
       @media (prefers-reduced-motion: reduce) {
         html { scroll-behavior: auto; }


### PR DESCRIPTION
## Summary
- Add `background-color: var(--bg)` on `html` so Safari's rubber-band overscroll no longer shows white — it falls back to the page's top color instead of the (ignored) gradient image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)