### PR TITLE
Fix black flicker when chart-head unsticks

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,8 +274,7 @@
         top: 56px;
         z-index: 5;
         padding: 6px 0;
-      }
-      .chart-head {
+        clip-path: inset(0);
         transition: background 0.15s ease, box-shadow 0.15s ease, clip-path 0.15s ease;
       }
       .chart-head.stuck {


### PR DESCRIPTION
## Summary
- `.chart-head.stuck` uses a 100vmax `box-shadow` clipped via `clip-path: inset(0 -100vmax)` to paint a full-width sticky backdrop.
- On unstick, `clip-path` can't interpolate to `none`, so it jumped off instantly while the box-shadow was still fading — exposing the full-viewport dark overlay for a frame.
- Fix: set `clip-path: inset(0)` on the base `.chart-head` so the transition animates between two valid `inset(...)` values in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)