### PR TITLE
Stop cropping chart-axis labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
         top: 56px;
         z-index: 5;
         padding: 6px 0;
-        clip-path: inset(0);
+        clip-path: inset(0 -32px);
         transition: background 0.15s ease, box-shadow 0.15s ease, clip-path 0.15s ease;
       }
       .chart-head.stuck {


### PR DESCRIPTION
## Summary
- The previous flicker fix set `clip-path: inset(0)` on `.chart-head`, which cropped the axis year labels (they're absolutely positioned with `translateX(-50%)` and extend slightly past the element's edges).
- Expand to `inset(0 -32px)` — keeps the flicker fix working (both stuck and unstuck states are valid `inset(...)` values for smooth interpolation) while leaving room for the labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)