### PR TITLE
Drop 'Member ·' from CTF row meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,7 +912,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">Itemize NTNU</span>
-                  <span class="meta">Member · security / CTF</span>
+                  <span class="meta">security / CTF</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-bar alt" style="left: 47.54%; width: 8.20%" title="Itemize · Sep 2015 — May 2017"></div>


### PR DESCRIPTION
## Summary
- Shortens the timeline CTF row's meta text from "Member · security / CTF" to "security / CTF".

🤖 Generated with [Claude Code](https://claude.com/claude-code)