### PR TITLE
Polish timeline consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
         <nav aria-label="Primary">
           <a href="#projects">Projects</a>
           <a href="#skills">Skills</a>
-          <a href="#experience">Timeline</a>
+          <a href="#timeline">Timeline</a>
           <a href="#contact">Contact</a>
         </nav>
       </div>
@@ -690,9 +690,9 @@
         </div>
       </section>
 
-      <section class="section" id="experience" aria-labelledby="experience-heading">
+      <section class="section" id="timeline" aria-labelledby="timeline-heading">
         <div class="container">
-          <h2 id="experience-heading">Timeline</h2>
+          <h2 id="timeline-heading">Timeline</h2>
           <div class="chart-toggle">
             <label>
               <input type="checkbox" id="show-subprojects">
@@ -729,34 +729,34 @@
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">Equinor mBot</span>
+                  <span class="company">Equinor — mBot</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 90.16%; width: 9.43%" title="Equinor mBot · May 2024 — now"></div>
+                  <div class="chart-bar current" style="left: 90.16%; width: 9.43%" title="Equinor — mBot · May 2024 — now"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">CV Partner LLM</span>
+                  <span class="company">CV Partner — LLM Experiments</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 88.52%; width: 1.23%" title="CV Partner · Jan 2024 — Apr 2024"></div>
+                  <div class="chart-bar" style="left: 88.52%; width: 1.23%" title="CV Partner — LLM Experiments · Jan 2024 — Apr 2024"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">BevarHMS AI-søk</span>
+                  <span class="company">BevarHMS — AI-søk</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 88.11%; width: 0.82%" title="BevarHMS · Dec 2023 — Feb 2024"></div>
+                  <div class="chart-bar" style="left: 88.11%; width: 0.82%" title="BevarHMS — AI-søk · Dec 2023 — Feb 2024"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">Webstep CV-assistent</span>
+                  <span class="company">Webstep — CV-assistent</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 83.61%; width: 4.51%" title="CV-assistent · Jan 2023 — Dec 2023"></div>
+                  <div class="chart-bar" style="left: 83.61%; width: 4.51%" title="Webstep — CV-assistent · Jan 2023 — Dec 2023"></div>
                 </div>
               </li>
               <li class="chart-row">
@@ -778,10 +778,10 @@
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">Pasienreiser</span>
+                  <span class="company">Pasientreiser</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 71.72%; width: 10.25%" title="Pasienreiser · Aug 2020 — Sep 2022"></div>
+                  <div class="chart-bar" style="left: 71.72%; width: 10.25%" title="Pasientreiser · Aug 2020 — Sep 2022"></div>
                 </div>
               </li>
               <li class="chart-row">
@@ -800,7 +800,7 @@
                   <span class="company">Glede Norway</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 75.82%; width: 2.46%" title="Glede Norway · App developer · Jun 2021 — Dec 2021"></div>
+                  <div class="chart-bar" style="left: 75.82%; width: 2.46%" title="Glede Norway · App Developer · Jun 2021 — Dec 2021"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">
@@ -824,7 +824,7 @@
                   <span class="company">Versor</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 65.16%; width: 0.41%" title="Versor · Web developer · Apr — May 2019"></div>
+                  <div class="chart-bar" style="left: 65.16%; width: 0.41%" title="Versor · Web Developer · Apr — May 2019"></div>
                 </div>
               </li>
               <li class="chart-row">
@@ -856,19 +856,19 @@
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">Summer job</span>
+                  <span class="company">Summer Job</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 51.23%; width: 0.82%" title="Summer job · Jun — Jul 2016"></div>
-                  <div class="chart-bar" style="left: 56.15%; width: 0.82%" title="Summer job · Jun — Jul 2017"></div>
+                  <div class="chart-bar" style="left: 51.23%; width: 0.82%" title="Summer Job · Jun — Jul 2016"></div>
+                  <div class="chart-bar" style="left: 56.15%; width: 0.82%" title="Summer Job · Jun — Jul 2017"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">Part-time</span>
+                  <span class="company">Part-Time</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 52.05%; width: 4.10%" title="Part-time · Aug 2016 — May 2017"></div>
+                  <div class="chart-bar" style="left: 52.05%; width: 4.10%" title="Part-Time · Aug 2016 — May 2017"></div>
                 </div>
               </li>
             </ol>
@@ -878,7 +878,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">dotKom NTNU</span>
-                  <span class="meta">Developer &amp; sysadmin</span>
+                  <span class="meta">Developer &amp; Sysadmin</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-bar alt" style="left: 47.13%; width: 23.77%" title="dotKom NTNU · Aug 2015 — Jun 2020"></div>
@@ -887,7 +887,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">Ascend NTNU</span>
-                  <span class="meta">Drone team</span>
+                  <span class="meta">Drone Team</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-bar alt" style="left: 52.46%; width: 9.43%" title="Ascend NTNU · Sep 2016 — Aug 2018"></div>
@@ -895,18 +895,18 @@
               </li>
               <li class="chart-row chart-subrow alt">
                 <div class="chart-label">
-                  <span class="company">AI developer</span>
+                  <span class="company">AI Developer</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar alt" style="left: 57.38%; width: 4.51%" title="AI developer · Sep 2017 — Aug 2018"></div>
+                  <div class="chart-bar alt" style="left: 57.38%; width: 4.51%" title="AI Developer · Sep 2017 — Aug 2018"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow alt">
                 <div class="chart-label">
-                  <span class="company">Web developer</span>
+                  <span class="company">Web Developer</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar alt" style="left: 52.46%; width: 4.51%" title="Web developer · Sep 2016 — Aug 2017"></div>
+                  <div class="chart-bar alt" style="left: 52.46%; width: 4.51%" title="Web Developer · Sep 2016 — Aug 2017"></div>
                 </div>
               </li>
               <li class="chart-row">
@@ -921,7 +921,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">Lektordokka</span>
-                  <span class="meta">Web developer</span>
+                  <span class="meta">Web Developer</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-bar alt" style="left: 43.03%; width: 5.74%" title="Lektordokka · Oct 2014 — Dec 2015"></div>
@@ -988,7 +988,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">Started coding</span>
-                  <span class="meta">2006 · age 9</span>
+                  <span class="meta">2006 · Age 9</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-marker personal trail-right" style="left: 0%" title="Started coding · 2006"></div>


### PR DESCRIPTION
## Summary
- **Typo**: `Pasienreiser` → `Pasientreiser` (timeline subrow + tooltip).
- **Title case** for all role labels and tooltips: `Summer Job`, `Part-Time`, `Developer & Sysadmin`, `Drone Team`, `AI Developer`, `Web Developer`, `App Developer`, `Age 9`.
- **Reuse card titles in subrows** (labels + tooltips): `Equinor — mBot`, `CV Partner — LLM Experiments`, `BevarHMS — AI-søk`, `Webstep — CV-assistent`.
- **Current glow** on the Equinor — mBot subrow (was only on the parent Webstep bar).
- **Anchor fix**: rename section id from `experience` to `timeline` so the nav link label matches the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)