### PR TITLE
Keep multi-word skills from wrapping mid-name

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,19 +672,19 @@
           <div class="grid stack">
             <div>
               <p class="col-label">Frontend</p>
-              <p class="col-body">React · TypeScript · Next.js · Tailwind · React Native · Vue · Angular · Storybook · Three.js · Playwright · D3.js</p>
+              <p class="col-body">React · TypeScript · Next.js · Tailwind · React&nbsp;Native · Vue · Angular · Storybook · Three.js · Playwright · D3.js</p>
             </div>
             <div>
               <p class="col-label">AI / LLM</p>
-              <p class="col-body">Claude · Claude Code · GPT · Gemini · Microsoft Agent Framework · Vercel AI SDK · MCP · AG-UI · Tool calling · Structured Outputs · RAG · pgVector · Qdrant · Jupyter Notebooks</p>
+              <p class="col-body">Claude · Claude&nbsp;Code · GPT · Gemini · Microsoft&nbsp;Agent&nbsp;Framework · Vercel&nbsp;AI&nbsp;SDK · MCP · AG-UI · Tool&nbsp;calling · Structured&nbsp;Outputs · RAG · pgVector · Qdrant · Jupyter&nbsp;Notebooks</p>
             </div>
             <div>
               <p class="col-label">Backend</p>
-              <p class="col-body">.NET · C# · Python · FastAPI · Pydantic · Node.js · PostgreSQL · Server-Sent Events · WebSockets · gRPC</p>
+              <p class="col-body">.NET · C# · Python · FastAPI · Pydantic · Node.js · PostgreSQL · Server-Sent&nbsp;Events · WebSockets · gRPC</p>
             </div>
             <div>
               <p class="col-label">Cloud</p>
-              <p class="col-body">Azure (OpenAI, AI Search, Container Apps, Functions, Entra ID) · AWS (Bedrock, Lambda, S3) · GCP Vertex AI · Firebase · GitHub Actions · Docker</p>
+              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, Container&nbsp;Apps, Functions, Entra&nbsp;ID) · AWS (Bedrock, Lambda, S3) · GCP&nbsp;Vertex&nbsp;AI · Firebase · GitHub&nbsp;Actions · Docker</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace whitespace inside multi-word tech names with non-breaking spaces so entries like `Container Apps`, `React Native`, `Claude Code`, `Microsoft Agent Framework`, `Vercel AI SDK`, `Tool calling`, `Structured Outputs`, `Jupyter Notebooks`, `Server-Sent Events`, `AI Search`, `Entra ID`, `GCP Vertex AI`, and `GitHub Actions` stay together. Wraps still happen freely between list items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)