### PR TITLE
Update cloud skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,7 +684,7 @@
             </div>
             <div>
               <p class="col-label">Cloud</p>
-              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, Container&nbsp;Apps, Functions, Entra&nbsp;ID) · AWS (Bedrock, Lambda, S3) · GCP&nbsp;Vertex&nbsp;AI · Firebase · GitHub&nbsp;Actions · Docker</p>
+              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, AI&nbsp;Foundry, Entra&nbsp;ID) · AWS&nbsp;Bedrock · GCP&nbsp;Vertex&nbsp;AI · Firebase · Supabase · Vercel · GitHub&nbsp;Actions · Docker</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -672,19 +672,19 @@
           <div class="grid stack">
             <div>
               <p class="col-label">Frontend</p>
-              <p class="col-body">React · TypeScript · Next.js · Tailwind · React Native · Vue · Angular · Storybook · Three.js · Playwright · D3.js</p>
+              <p class="col-body">React · TypeScript · Next.js · Tailwind · React&nbsp;Native · Vue · Angular · Storybook · Three.js · Playwright · D3.js</p>
             </div>
             <div>
               <p class="col-label">AI / LLM</p>
-              <p class="col-body">Claude · Claude Code · GPT · Gemini · Microsoft Agent Framework · Vercel AI SDK · MCP · AG-UI · Tool calling · Structured Outputs · RAG · pgVector · Qdrant · Jupyter Notebooks</p>
+              <p class="col-body">Claude · Claude&nbsp;Code · GPT · Gemini · Microsoft&nbsp;Agent&nbsp;Framework · Vercel&nbsp;AI&nbsp;SDK · MCP · AG-UI · Tool&nbsp;calling · Structured&nbsp;Outputs · RAG · pgVector · Qdrant · Jupyter&nbsp;Notebooks</p>
             </div>
             <div>
               <p class="col-label">Backend</p>
-              <p class="col-body">.NET · C# · Python · FastAPI · Pydantic · Node.js · PostgreSQL · Server-Sent Events · WebSockets · gRPC</p>
+              <p class="col-body">.NET · C# · Python · FastAPI · Pydantic · Node.js · PostgreSQL · Server-Sent&nbsp;Events · WebSockets · gRPC</p>
             </div>
             <div>
               <p class="col-label">Cloud</p>
-              <p class="col-body">Azure (OpenAI, AI Search, Container Apps, Functions, Entra ID) · AWS (Bedrock, Lambda, S3) · GCP Vertex AI · Firebase · GitHub Actions · Docker</p>
+              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, Container&nbsp;Apps, Functions, Entra&nbsp;ID) · AWS (Bedrock, Lambda, S3) · GCP&nbsp;Vertex&nbsp;AI · Firebase · GitHub&nbsp;Actions · Docker</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -672,19 +672,19 @@
           <div class="grid stack">
             <div>
               <p class="col-label">Frontend</p>
-              <p class="col-body">React · TypeScript · Next.js · Tailwind · React&nbsp;Native · Vue · Angular · Storybook · Three.js · Playwright · D3.js</p>
+              <p class="col-body">React&nbsp;· TypeScript&nbsp;· Next.js&nbsp;· Tailwind&nbsp;· React&nbsp;Native&nbsp;· Vue&nbsp;· Angular&nbsp;· Storybook&nbsp;· Three.js&nbsp;· Playwright&nbsp;· D3.js</p>
             </div>
             <div>
               <p class="col-label">AI / LLM</p>
-              <p class="col-body">Claude · Claude&nbsp;Code · GPT · Gemini · Microsoft&nbsp;Agent&nbsp;Framework · Vercel&nbsp;AI&nbsp;SDK · MCP · AG-UI · Tool&nbsp;calling · Structured&nbsp;Outputs · RAG · pgVector · Qdrant · Jupyter&nbsp;Notebooks</p>
+              <p class="col-body">Claude&nbsp;· Claude&nbsp;Code&nbsp;· GPT&nbsp;· Gemini&nbsp;· Microsoft&nbsp;Agent&nbsp;Framework&nbsp;· Vercel&nbsp;AI&nbsp;SDK&nbsp;· MCP&nbsp;· AG-UI&nbsp;· Tool&nbsp;calling&nbsp;· Structured&nbsp;Outputs&nbsp;· RAG&nbsp;· pgVector&nbsp;· Qdrant&nbsp;· Jupyter&nbsp;Notebooks</p>
             </div>
             <div>
               <p class="col-label">Backend</p>
-              <p class="col-body">.NET · C# · Python · FastAPI · Pydantic · Node.js · PostgreSQL · Server-Sent&nbsp;Events · WebSockets · gRPC</p>
+              <p class="col-body">.NET&nbsp;· C#&nbsp;· Python&nbsp;· FastAPI&nbsp;· Pydantic&nbsp;· Node.js&nbsp;· PostgreSQL&nbsp;· Server-Sent&nbsp;Events&nbsp;· WebSockets&nbsp;· gRPC</p>
             </div>
             <div>
               <p class="col-label">Cloud</p>
-              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, AI&nbsp;Foundry) · AWS&nbsp;Bedrock · GCP&nbsp;Vertex&nbsp;AI · Firebase · Supabase · Vercel · GitHub&nbsp;Actions · Docker</p>
+              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, AI&nbsp;Foundry)&nbsp;· AWS&nbsp;Bedrock&nbsp;· GCP&nbsp;Vertex&nbsp;AI&nbsp;· Firebase&nbsp;· Supabase&nbsp;· Vercel&nbsp;· GitHub&nbsp;Actions&nbsp;· Docker</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -684,7 +684,7 @@
             </div>
             <div>
               <p class="col-label">Cloud</p>
-              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, AI&nbsp;Foundry, Entra&nbsp;ID) · AWS&nbsp;Bedrock · GCP&nbsp;Vertex&nbsp;AI · Firebase · Supabase · Vercel · GitHub&nbsp;Actions · Docker</p>
+              <p class="col-body">Azure (OpenAI, AI&nbsp;Search, AI&nbsp;Foundry) · AWS&nbsp;Bedrock · GCP&nbsp;Vertex&nbsp;AI · Firebase · Supabase · Vercel · GitHub&nbsp;Actions · Docker</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@
             </div>
             <div>
               <p class="col-label">AI / LLM</p>
-              <p class="col-body">Claude&nbsp;· Claude&nbsp;Code&nbsp;· GPT&nbsp;· Gemini&nbsp;· Microsoft&nbsp;Agent&nbsp;Framework&nbsp;· Vercel&nbsp;AI&nbsp;SDK&nbsp;· MCP&nbsp;· AG-UI&nbsp;· Tool&nbsp;calling&nbsp;· Structured&nbsp;Outputs&nbsp;· RAG&nbsp;· pgVector&nbsp;· Qdrant&nbsp;· Jupyter&nbsp;Notebooks</p>
+              <p class="col-body">Claude&nbsp;· Claude&nbsp;Code&nbsp;· GPT&nbsp;· Gemini&nbsp;· MAF&nbsp;· Vercel&nbsp;AI&nbsp;SDK&nbsp;· MCP&nbsp;· AG-UI&nbsp;· Tool&nbsp;calling&nbsp;· Structured&nbsp;Outputs&nbsp;· RAG&nbsp;· pgVector&nbsp;· Qdrant&nbsp;· Jupyter&nbsp;Notebooks</p>
             </div>
             <div>
               <p class="col-label">Backend</p>


### PR DESCRIPTION
## Summary
- Azure: remove Container Apps and Functions, add AI Foundry.
- AWS: drop Lambda and S3 (keep Bedrock).
- Add Supabase and Vercel to the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)