### PR TITLE
SEO meta tags and Person schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,48 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Niklas Molnes Hole — Fullstack & LLM engineer</title>
-    <meta name="description" content="Fullstack and LLM engineer based in Oslo. Currently Frontend Lead at Equinor building LLM-powered agents." />
+    <meta name="description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <meta name="author" content="Niklas Molnes Hole" />
+    <meta name="theme-color" content="#0a0a0f" />
+    <link rel="canonical" href="https://niklasmh.no/" />
 
-    <meta property="og:title" content="Niklas Molnes Hole — Fullstack & LLM engineer" />
-    <meta property="og:description" content="Fullstack and LLM engineer based in Oslo." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://niklasmh.no" />
+    <meta property="og:site_name" content="Niklas Molnes Hole" />
+    <meta property="og:title" content="Niklas Molnes Hole — Fullstack & LLM engineer" />
+    <meta property="og:description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <meta property="og:url" content="https://niklasmh.no/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:image" content="https://github.com/niklasmh.png?size=1200" />
+    <meta property="og:image:alt" content="Niklas Molnes Hole" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Niklas Molnes Hole — Fullstack & LLM engineer" />
+    <meta name="twitter:description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <meta name="twitter:image" content="https://github.com/niklasmh.png?size=1200" />
+    <meta name="twitter:creator" content="@niklashole" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Niklas Molnes Hole",
+        "url": "https://niklasmh.no/",
+        "image": "https://github.com/niklasmh.png",
+        "jobTitle": "Frontend Lead & Prompt Engineer",
+        "description": "Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG.",
+        "worksFor": { "@type": "Organization", "name": "Equinor" },
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Oslo",
+          "addressCountry": "NO"
+        },
+        "sameAs": [
+          "https://github.com/niklasmh",
+          "https://linkedin.com/in/niklasmh",
+          "https://x.com/niklashole"
+        ]
+      }
+    </script>
 
     <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">👨‍💻</text></svg>' />
 


### PR DESCRIPTION
## Summary
- Flesh out the `<head>` for SEO and nicer Google / social previews:
  - Refined `meta description` (keyword-rich, under 160 chars).
  - Add `meta author`, `theme-color`, and a `canonical` link.
  - Full Open Graph tags (`site_name`, `locale`, `image`, `image:alt`) using the GitHub avatar as the default card image.
  - Twitter `summary_large_image` card with `creator` handle.
  - JSON-LD `Person` schema covering role, employer, location, and external profiles — so Google can assemble a knowledge panel.

## Notes
- Social image defaults to `https://github.com/niklasmh.png?size=1200` (square GitHub avatar). Swap for a dedicated 1200×630 banner when one is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)