### PR TITLE
Broaden SEO copy to AI engineering focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,24 +3,24 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Niklas Molnes Hole — AI engineer · UI & agents</title>
-    <meta name="description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
+    <title>Niklas Molnes Hole — LLM engineer · UI & agents</title>
+    <meta name="description" content="LLM engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta name="author" content="Niklas Molnes Hole" />
     <meta name="theme-color" content="#0a0a0f" />
     <link rel="canonical" href="https://niklasmh.no/" />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Niklas Molnes Hole" />
-    <meta property="og:title" content="Niklas Molnes Hole — AI engineer · UI & agents" />
-    <meta property="og:description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
+    <meta property="og:title" content="Niklas Molnes Hole — LLM engineer · UI & agents" />
+    <meta property="og:description" content="LLM engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta property="og:url" content="https://niklasmh.no/" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:image" content="https://github.com/niklasmh.png?size=1200" />
     <meta property="og:image:alt" content="Niklas Molnes Hole" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Niklas Molnes Hole — AI engineer · UI & agents" />
-    <meta name="twitter:description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
+    <meta name="twitter:title" content="Niklas Molnes Hole — LLM engineer · UI & agents" />
+    <meta name="twitter:description" content="LLM engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta name="twitter:image" content="https://github.com/niklasmh.png?size=1200" />
     <meta name="twitter:creator" content="@niklashole" />
 
@@ -31,8 +31,8 @@
         "name": "Niklas Molnes Hole",
         "url": "https://niklasmh.no/",
         "image": "https://github.com/niklasmh.png",
-        "jobTitle": "AI engineer",
-        "description": "AI engineer focused on UIs and agents. Fullstack engineer based in Oslo.",
+        "jobTitle": "LLM engineer",
+        "description": "LLM engineer focused on UIs and agents. Fullstack engineer based in Oslo.",
         "worksFor": { "@type": "Organization", "name": "Equinor" },
         "address": {
           "@type": "PostalAddress",

--- a/index.html
+++ b/index.html
@@ -3,24 +3,24 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Niklas Molnes Hole — Fullstack & LLM engineer</title>
-    <meta name="description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <title>Niklas Molnes Hole — AI engineer · UI & agents</title>
+    <meta name="description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta name="author" content="Niklas Molnes Hole" />
     <meta name="theme-color" content="#0a0a0f" />
     <link rel="canonical" href="https://niklasmh.no/" />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Niklas Molnes Hole" />
-    <meta property="og:title" content="Niklas Molnes Hole — Fullstack & LLM engineer" />
-    <meta property="og:description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <meta property="og:title" content="Niklas Molnes Hole — AI engineer · UI & agents" />
+    <meta property="og:description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta property="og:url" content="https://niklasmh.no/" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:image" content="https://github.com/niklasmh.png?size=1200" />
     <meta property="og:image:alt" content="Niklas Molnes Hole" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Niklas Molnes Hole — Fullstack & LLM engineer" />
-    <meta name="twitter:description" content="Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG." />
+    <meta name="twitter:title" content="Niklas Molnes Hole — AI engineer · UI & agents" />
+    <meta name="twitter:description" content="AI engineer focused on UIs and agents. Fullstack engineer based in Oslo." />
     <meta name="twitter:image" content="https://github.com/niklasmh.png?size=1200" />
     <meta name="twitter:creator" content="@niklashole" />
 
@@ -31,8 +31,8 @@
         "name": "Niklas Molnes Hole",
         "url": "https://niklasmh.no/",
         "image": "https://github.com/niklasmh.png",
-        "jobTitle": "Frontend Lead & Prompt Engineer",
-        "description": "Fullstack and LLM engineer based in Oslo. Frontend Lead at Equinor, building LLM-powered agents with generative AI and RAG.",
+        "jobTitle": "AI engineer",
+        "description": "AI engineer focused on UIs and agents. Fullstack engineer based in Oslo.",
         "worksFor": { "@type": "Organization", "name": "Equinor" },
         "address": {
           "@type": "PostalAddress",


### PR DESCRIPTION
## Summary
- Reframe the title, meta/OG/Twitter descriptions, and JSON-LD `jobTitle` around "AI engineer · UI & agents" rather than the current-role specifics. Keeps the copy durable when the role changes; employer and social profiles stay in the Person schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)