### PR TITLE
Add Study 3D graphics and AI/LLMs to personal timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,6 +980,24 @@
             <ol class="chart-rows">
               <li class="chart-row">
                 <div class="chart-label">
+                  <span class="company">Study AI/LLMs</span>
+                  <span class="meta">Self-study</span>
+                </div>
+                <div class="chart-track">
+                  <div class="chart-bar personal" style="left: 83.61%; width: 15.98%" title="Study AI/LLMs · Jan 2023 — now"></div>
+                </div>
+              </li>
+              <li class="chart-row">
+                <div class="chart-label">
+                  <span class="company">Study 3D graphics</span>
+                  <span class="meta">Self-study</span>
+                </div>
+                <div class="chart-track">
+                  <div class="chart-bar personal" style="left: 71.72%; width: 11.89%" title="Study 3D graphics · Aug 2020 — Dec 2022"></div>
+                </div>
+              </li>
+              <li class="chart-row">
+                <div class="chart-label">
                   <span class="company">NTNU</span>
                   <span class="meta">Informatics</span>
                 </div>

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
               <li class="chart-row">
                 <div class="chart-label">
                   <span class="company">Startups</span>
-                  <span class="meta">Various</span>
+                  <span class="meta">Part-Time</span>
                 </div>
                 <div class="chart-track">
                   <div class="chart-bar" style="left: 65.16%; width: 0.41%" title="Versor · Apr — May 2019"></div>


### PR DESCRIPTION
## Summary
- Add two personal self-study rows above the NTNU bar:
  - **Study 3D graphics** — Aug 2020 — Dec 2022
  - **Study AI/LLMs** — Jan 2023 — now
- Both use the existing `.chart-bar.personal` style (green gradient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)