### PR TITLE
Relabel NTNU row as University · Computer Science @ NTNU

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,11 +1007,11 @@
               </li>
               <li class="chart-row">
                 <div class="chart-label">
-                  <span class="company">NTNU</span>
-                  <span class="meta">Informatics</span>
+                  <span class="company">University</span>
+                  <span class="meta">Computer Science @ NTNU</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar personal" style="left: 47.13%; width: 23.77%" title="NTNU · Informatics · 2015 — 2020"></div>
+                  <div class="chart-bar personal" style="left: 47.13%; width: 23.77%" title="University · Computer Science @ NTNU · 2015 — 2020"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow personal">
@@ -1019,7 +1019,7 @@
                   <span class="company">MSc · Databases &amp; Search</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar personal" style="left: 61.89%; width: 9.02%" title="MSc Informatics · Databases &amp; Search · 2018 — 2020"></div>
+                  <div class="chart-bar personal" style="left: 61.89%; width: 9.02%" title="MSc Computer Science · Databases &amp; Search · 2018 — 2020"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow personal">
@@ -1027,7 +1027,7 @@
                   <span class="company">BSc</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar personal" style="left: 47.13%; width: 13.93%" title="BSc Informatics · 2015 — 2018"></div>
+                  <div class="chart-bar personal" style="left: 47.13%; width: 13.93%" title="BSc Computer Science · 2015 — 2018"></div>
                 </div>
               </li>
               <li class="chart-row">


### PR DESCRIPTION
## Summary
- Rename the personal NTNU row label from `NTNU / Informatics` to `University / Computer Science @ NTNU`.
- Update the MSc and BSc subrow tooltips from "Informatics" → "Computer Science" for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)