### PR TITLE
Refine project card wording and rename CV Partner to Flowcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,8 +740,8 @@
             </article>
             <article class="card">
               <p class="card-date">2024</p>
-              <h3>CV Partner — LLM Experiments</h3>
-              <p class="card-meta">AI Engineer · Frontend — AWS Bedrock, React, Python, Flask</p>
+              <h3>Flowcase — LLM Experiments</h3>
+              <p class="card-meta">AI Engineer · Frontend · R&amp;D — AWS Bedrock, React, Python</p>
               <p class="card-body">Built PoC tools with Flowcase (CV Partner) for AI-assisted CV tailoring and tender reference-project write-ups, plus an internal app to compare LLMs side-by-side.</p>
               <div class="card-refs">
                 <p class="card-refs-label">References</p>
@@ -753,13 +753,13 @@
             <article class="card">
               <p class="card-date">2023 — 2024</p>
               <h3>BevarHMS — AI-søk</h3>
-              <p class="card-meta">AI Engineer · Frontend — OpenAI, vector embeddings, React</p>
-              <p class="card-body">Natural-language search over statutory HSE documentation for housing cooperatives — custom retrieval with LLMs and vector embeddings, plus a UI built to make it approachable for non-specialist users.</p>
+              <p class="card-meta">AI Engineer · Frontend — OpenAI, RAG, React</p>
+              <p class="card-body">Natural-language search over legally required HSE documentation for housing cooperatives — custom retrieval with LLMs and vector embeddings, plus a UI built to make it approachable for non-specialist users.</p>
             </article>
             <article class="card">
               <p class="card-date">2023</p>
               <h3>Webstep — CV-assistent</h3>
-              <p class="card-meta">Frontend · AI Engineer — GPT-4, RAG, React</p>
+              <p class="card-meta">AI Engineer · Frontend — OpenAI, RAG, React</p>
               <p class="card-body">RAG tool that matches and scores consultant CVs against client requirements, flags qualification gaps, and drafts tailored summaries — advisors stay in the loop for final review.</p>
               <div class="card-refs">
                 <p class="card-refs-label">References</p>
@@ -851,10 +851,10 @@
               </li>
               <li class="chart-row chart-subrow">
                 <div class="chart-label">
-                  <span class="company">CV Partner — LLM Experiments</span>
+                  <span class="company">Flowcase — LLM Experiments</span>
                 </div>
                 <div class="chart-track">
-                  <div class="chart-bar" style="left: 88.52%; width: 1.64%" title="CV Partner — LLM Experiments · Jan 2024 — May 2024"></div>
+                  <div class="chart-bar" style="left: 88.52%; width: 1.64%" title="Flowcase — LLM Experiments · Jan 2024 — May 2024"></div>
                 </div>
               </li>
               <li class="chart-row chart-subrow">

--- a/llms.txt
+++ b/llms.txt
@@ -13,9 +13,9 @@
 ## Recent projects
 
 - Equinor — mBot (2024 — now). Frontend Lead & AI Engineer; Azure, React, RAG, text-to-SQL. Agentic AI chatbot surfacing 50 years of Equinor's drilling and well expertise via RAG and text-to-SQL — one of Equinor's five flagship AI projects. Article: https://webstep.no/fra-nytt-til-nyttig/hvordan-ai-gjor-50-ar-med-bore-og-bronnerfaring-sokbar-og-tilgjengelig
-- CV Partner — LLM Experiments (2024). AI Engineer & Frontend; AWS Bedrock, React, Python, Flask. Built PoC tools with Flowcase (CV Partner) for AI-assisted CV tailoring and tender reference-project write-ups, plus an internal app to compare LLMs side-by-side. Article: https://content.webstep.no/cv-partner/
-- BevarHMS — AI-søk (2023 — 2024). AI Engineer & Frontend; OpenAI, vector embeddings, React. Natural-language search over statutory HSE documentation for housing cooperatives — custom retrieval with LLMs and vector embeddings, plus a UI built to make it approachable for non-specialist users.
-- Webstep — CV-assistent (2023). Frontend & AI Engineer; GPT-4, RAG, React. RAG tool that matches and scores consultant CVs against client requirements, flags qualification gaps, and drafts tailored summaries — advisors stay in the loop for final review. Article: https://webstep.no/fra-nytt-til-nyttig/en-effektiv-cv-skreddersom
+- Flowcase — LLM Experiments (2024). AI Engineer, Frontend & R&D; AWS Bedrock, React, Python. Built PoC tools with Flowcase (CV Partner) for AI-assisted CV tailoring and tender reference-project write-ups, plus an internal app to compare LLMs side-by-side. Article: https://content.webstep.no/cv-partner/
+- BevarHMS — AI-søk (2023 — 2024). AI Engineer & Frontend; OpenAI, RAG, React. Natural-language search over legally required HSE documentation for housing cooperatives — custom retrieval with LLMs and vector embeddings, plus a UI built to make it approachable for non-specialist users.
+- Webstep — CV-assistent (2023). AI Engineer & Frontend; OpenAI, RAG, React. RAG tool that matches and scores consultant CVs against client requirements, flags qualification gaps, and drafts tailored summaries — advisors stay in the loop for final review. Article: https://webstep.no/fra-nytt-til-nyttig/en-effektiv-cv-skreddersom
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Follow-up wording pass on the project cards, with matching updates in `llms.txt`.

- **Rename CV Partner → Flowcase** in the card title and the timeline row (label + hover tooltip). `Flowcase (CV Partner)` is kept in the card body so the former name is still discoverable, and the article URL is unchanged.
- **Flowcase card:** drop Flask from the stack, add R&D to the role line
- **CV-assistent card:** lead with AI Engineer rather than Frontend; use OpenAI instead of GPT-4
- **BevarHMS card:** "statutory" → "legally required" (plainer, and closer to the original Norwegian *lovpålagt*); vector embeddings → RAG in the role line

## Verification
- Rendered and inspected in-browser; card titles, role lines and timeline labels confirmed via DOM extraction
- Audited body → head metadata → `llms.txt` for consistency: all facts match across the three layers
- `grep` confirms Flask is gone and the only remaining "CV Partner" references are the two intended parentheticals plus the article URL

## Known follow-up
BevarHMS's role line now says RAG while its body still reads "custom retrieval with LLMs and vector embeddings". Both files agree, so they are in sync, but the wording is worth revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)