### PR TITLE
Add LinkedIn reference to the mBot project

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
       .card-refs-list { list-style: none; margin: 0; padding: 0; }
       .card-refs-list li {
         font-size: 13px;
-        margin: 0 0 2px;
+        margin: 0 0 7px;
       }
       .card-refs-list li:last-child { margin-bottom: 0; }
       .card-refs-list a {
@@ -735,6 +735,7 @@
                 <p class="card-refs-label">References</p>
                 <ul class="card-refs-list">
                   <li><a href="https://webstep.no/fra-nytt-til-nyttig/hvordan-ai-gjor-50-ar-med-bore-og-bronnerfaring-sokbar-og-tilgjengelig" target="_blank" rel="noopener">How AI makes 50 years of drilling and well experience searchable and accessible <span class="ref-arrow">↗</span></a></li>
+                  <li><a href="https://www.linkedin.com/posts/hegeskryseth_episode-5-five-ways-equinor-uses-ai-who-ugcPost-7327950108648431616-qlQ9" target="_blank" rel="noopener">Episode 5: Five ways Equinor uses AI <span class="ref-arrow">↗</span></a></li>
                 </ul>
               </div>
             </article>

--- a/llms.txt
+++ b/llms.txt
@@ -12,10 +12,10 @@
 
 ## Recent projects
 
-- Equinor — mBot (2024 — now). Frontend Lead & AI Engineer; Azure, React, RAG, text-to-SQL. Agentic AI chatbot surfacing 50 years of Equinor's drilling and well expertise via RAG and text-to-SQL — one of Equinor's five flagship AI projects. Article: https://webstep.no/fra-nytt-til-nyttig/hvordan-ai-gjor-50-ar-med-bore-og-bronnerfaring-sokbar-og-tilgjengelig
-- Flowcase — LLM Experiments (2024). AI Engineer, Frontend & R&D; AWS Bedrock, React, Python. Built PoC tools with Flowcase (CV Partner) for AI-assisted CV tailoring and tender reference-project write-ups, plus an internal app to compare LLMs side-by-side. Article: https://content.webstep.no/cv-partner/
+- Equinor — mBot (2024 — now). Frontend Lead & AI Engineer; Azure, React, RAG, text-to-SQL. Agentic AI chatbot surfacing 50 years of Equinor's drilling and well expertise via RAG and text-to-SQL — one of Equinor's five flagship AI projects. References: https://webstep.no/fra-nytt-til-nyttig/hvordan-ai-gjor-50-ar-med-bore-og-bronnerfaring-sokbar-og-tilgjengelig | https://www.linkedin.com/posts/hegeskryseth_episode-5-five-ways-equinor-uses-ai-who-ugcPost-7327950108648431616-qlQ9
+- Flowcase — LLM Experiments (2024). AI Engineer, Frontend & R&D; AWS Bedrock, React, Python. Built PoC tools with Flowcase (CV Partner) for AI-assisted CV tailoring and tender reference-project write-ups, plus an internal app to compare LLMs side-by-side. References: https://content.webstep.no/cv-partner/
 - BevarHMS — AI-søk (2023 — 2024). AI Engineer & Frontend; OpenAI, RAG, React. Natural-language search over legally required HSE documentation for housing cooperatives — custom retrieval with LLMs and vector embeddings, plus a UI built to make it approachable for non-specialist users.
-- Webstep — CV-assistent (2023). AI Engineer & Frontend; OpenAI, RAG, React. RAG tool that matches and scores consultant CVs against client requirements, flags qualification gaps, and drafts tailored summaries — advisors stay in the loop for final review. Article: https://webstep.no/fra-nytt-til-nyttig/en-effektiv-cv-skreddersom
+- Webstep — CV-assistent (2023). AI Engineer & Frontend; OpenAI, RAG, React. RAG tool that matches and scores consultant CVs against client requirements, flags qualification gaps, and drafts tailored summaries — advisors stay in the loop for final review. References: https://webstep.no/fra-nytt-til-nyttig/en-effektiv-cv-skreddersom
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Adds Hege Skryseth's LinkedIn post ["Episode 5: Five ways Equinor uses AI"](https://www.linkedin.com/posts/hegeskryseth_episode-5-five-ways-equinor-uses-ai-who-ugcPost-7327950108648431616-qlQ9) as a second reference on the Equinor — mBot card. The post describes mBot directly and is the source for the card's "one of Equinor's five flagship AI projects" claim.

Also included:
- **Reference list spacing** bumped from 2px to 7px. With one reference per card this was invisible, but the mBot card's first entry wraps to two lines, and the gap between entries was indistinguishable from the gap between wrapped lines.
- **`llms.txt`** mirrored, with the key renamed `Article:` → `References:` across all entries so it matches the card label and reads correctly now that one project has two.

## Verification
- Rendered in-browser; both references confirmed present with correct hrefs via DOM extraction
- Visually checked the two-item list before and after the spacing change

🤖 Generated with [Claude Code](https://claude.com/claude-code)