### PR TITLE
Label the mBot LinkedIn reference by its source

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@
                 <p class="card-refs-label">References</p>
                 <ul class="card-refs-list">
                   <li><a href="https://webstep.no/fra-nytt-til-nyttig/hvordan-ai-gjor-50-ar-med-bore-og-bronnerfaring-sokbar-og-tilgjengelig" target="_blank" rel="noopener">How AI makes 50 years of drilling and well experience searchable and accessible <span class="ref-arrow">↗</span></a></li>
-                  <li><a href="https://www.linkedin.com/posts/hegeskryseth_episode-5-five-ways-equinor-uses-ai-who-ugcPost-7327950108648431616-qlQ9" target="_blank" rel="noopener">Episode 5: Five ways Equinor uses AI <span class="ref-arrow">↗</span></a></li>
+                  <li><a href="https://www.linkedin.com/posts/hegeskryseth_episode-5-five-ways-equinor-uses-ai-who-ugcPost-7327950108648431616-qlQ9" target="_blank" rel="noopener">LinkedIn: Five ways Equinor uses AI <span class="ref-arrow">↗</span></a></li>
                 </ul>
               </div>
             </article>


### PR DESCRIPTION
## Summary

Renames the second reference on the Equinor — mBot card from "Episode 5: Five ways Equinor uses AI" to **"LinkedIn: Five ways Equinor uses AI"**.

The "Episode 5:" prefix carried no meaning outside the original post series. Naming the source instead also distinguishes the post from the Webstep article listed above it — previously both read as the same kind of link.

The URL is unchanged, and `llms.txt` needs no update since it stores reference URLs without titles.

## Verification
- Rendered in-browser and confirmed the link text via DOM extraction
- `grep` confirms no remaining "Episode" text outside the URL slug itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)